### PR TITLE
Xs 5 improved library methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,337 +1,81 @@
-# XY-SK120 Modbus RTU Communication Library
+# XY-SK120 Modbus RTU Control
 
-Version: 0.0.1
+This project allows you to control an XY-SK120 power supply (and compatible models) over Modbus RTU using a Seeed XIAO ESP32S3.
 
-This library provides a simple interface to communicate with the XY-SK series DC-DC buck-boost power supply modules (specifically the XY-SK120) digital power supply (DPS) using Modbus RTU protocol over a TTL serial connection.
+## Features
 
-## Overview
+- Serial monitor control interface
+- Memory group management
+- Direct register access for debugging
+- Web interface (coming soon)
 
-The XY-SK120 is a DC-DC buck-boost power supply module with a voltage range of 0.5-30V and current range of 0-5A. It supports Modbus RTU communication for remote control and monitoring. Recommend to keep the output within 120W.
+## Hardware Setup
 
-This library allows you to:
-- Set voltage and current limits
-- Monitor actual voltage, current, and power
-- Turn the output on/off
-- Use constant voltage (CV) or constant current (CC) modes
-- Configure protection settings
-- Read device information and status
-- Control various device settings like backlight, buzzer, etc.
+- Connect the XIAO ESP32S3 to the XY-SK120 using the TTL interface:
+  - XIAO TX pin → XY-SK120 RX pin
+  - XIAO RX pin → XY-SK120 TX pin
+  - XIAO GND → XY-SK120 GND
 
-With a open source libraries that is based on Arduino framework.
+## Serial Monitor Commands
 
-## Quickstart
+### Basic Commands
 
-- Clone this repo and open it with PlatformIO
-- Hook up the XY-SK120 DPS with a SeeedStudio XIAO ESP32S3 on it's serial RX and TX pin
-- Compile and upload
-- Interface the DPS with serial monitor
-- Type `help` in the serial monitor to bring up the list of commands
-
-## Use it as a library
-
-- Simply download the `XY-SKxxx` from the `lib` folder and place it to your PlatformIO project inside the `lib` folder
-- `#include "XY-SKxxx.h"` in your `main.cpp` 
-- Start coding!
-
-## Hardware Requirements
-
-- XY-SK120 (or compatible) DC-DC buck-boost power supply module
-- A Seeedstudio XIAO ESP32S3 board (tested) or any Arduino-compatible board with hardware or software serial support (untested)
-- TTL to RS-485/Modbus converter (optional, direct TTL connection also works)
-
-## Different Models of DPS
-
-There seems to be a number of brands / manufacturers making a very similar power supply module and possibly using the same MCU with a very similar hardware to control the functionalities of the DPS - they seem to vary only on certain additional functionalities such as different maximum input / output voltage, different add-on connectivity board such as the Sinilink ESP8285H16 TTL-WIFI adaptor or a unknown TTL-USB / TTL-Bluetooth adaptor, in order to provide additional interface such as Windows app / mobile app over WIFI or Bluetooth.
-
-## Documentations
-
-- See 'Documentation' folder for a 'user manual' and additional findings and most importantly, the Modbus-RTU registers for the control of the DPS.
-
-## Pin Connections
-
-For XIAO ESP32S3 (default in example code):
-- Connect power supply GND to XIAO ESP32S3 GND
-- Connect power supply RX to XIAO ESP32S3 D6 (TX)
-- Connect power supply TX to XIAO ESP32S3 D7 (RX)
-
-## Installation
-
-1. Clone this repository to a local folder with VS Code and Platform IO installed:
-   ```
-   git clone https://github.com/csvke/XY-SK120-Modbus-RTU-TTL.git
-   ```
-
-2. Choose 'Open Project' from the Platform IO 'PIO Home' page
-
-
-## Dependencies
-
-- [ModbusMaster](https://github.com/4-20ma/ModbusMaster)
-
-## Usage
-
-### Basic Setup
-
-```cpp
-#include <Arduino.h>
-#include "XY-SKxxx.h"
-#include "XY-SKxxx_Config.h"  // Include the configuration header
-
-// Initialize configuration
-XYModbusConfig config;
-XY_SKxxx* powerSupply = nullptr;
-
-void setup() {
-  Serial.begin(115200);
-  
-  // Initialize configuration manager (loads from NVS on ESP32)
-  XYConfigManager::begin();
-  config = XYConfigManager::loadConfig();
-  
-  // Create power supply instance with loaded configuration
-  powerSupply = new XY_SKxxx(config.rxPin, config.txPin, config.slaveId);
-  
-  // Initialize the power supply with the configured baud rate
-  powerSupply->begin(config.baudRate);
-  
-  // Test connection
-  if (powerSupply->testConnection()) {
-    Serial.println("Connection successful.");
-  } else {
-    Serial.println("Connection failed.");
-  }
-}
-```
-
-### Configuration Management
-
-The library includes a configuration management system that stores connection settings in non-volatile storage on ESP32:
-
-```cpp
-// Save current configuration
-XYConfigManager::saveConfig(config);
-
-// Reset to default configuration
-XYConfigManager::resetConfig();
-
-// Check if configuration exists
-bool hasConfig = XYConfigManager::configExists();
-```
-
-### Setting Voltage and Current
-
-```cpp
-// Set voltage to 5.0V and current to 1.0A
-powerSupply->setVoltageAndCurrent(5.0, 1.0);
-
-// Or set them individually
-powerSupply->setVoltage(5.0);  // Set to 5.0V
-powerSupply->setCurrent(1.0);  // Set to 1.0A
-```
-
-### Constant Voltage/Current Modes
-
-```cpp
-// Set constant voltage mode to 12V
-XY_SK120.setConstantVoltage(12.0);
-
-// Set constant current mode to 0.5A
-XY_SK120.setConstantCurrent(0.5);
-
-// Check current operating mode
-if (XY_SK120.isInConstantCurrentMode()) {
-  Serial.println("Operating in Constant Current (CC) mode");
-} else if (XY_SK120.isInConstantVoltageMode()) {
-  Serial.println("Operating in Constant Voltage (CV) mode");
-}
-```
-
-### Turning Output On/Off
-
-```cpp
-// Turn output on
-XY_SK120.turnOutputOn();
-
-// Turn output off
-XY_SK120.turnOutputOff();
-```
-
-### Reading Output Status
-
-```cpp
-float voltage, current, power;
-bool isOn;
-
-if (powerSupply->getOutputStatus(voltage, current, power, isOn)) {
-  Serial.print("Voltage: "); Serial.print(voltage, 2); Serial.println(" V");
-  Serial.print("Current: "); Serial.print(current, 3); Serial.println(" A");
-  Serial.print("Power: "); Serial.print(power, 3); Serial.println(" W");
-  Serial.print("Output: "); Serial.println(isOn ? "ON" : "OFF");
-}
-```
-
-### Protection Settings
-
-```cpp
-// Set over-voltage protection to 30V
-XY_SK120.setOverVoltageProtection(30.0);
-
-// Set over-current protection to 5A
-XY_SK120.setOverCurrentProtection(5.0);
-
-// Set over-power protection to 150W
-XY_SK120.setOverPowerProtection(150.0);
-
-// Set over-temperature protection to 80°C
-XY_SK120.setOverTemperatureProtection(80.0);
-```
-
-## Serial Command Interface
-
-The included example sketches provide a simple serial command interface to control the XY-SK120:
-
-- `<voltage> <current>` - Set voltage and current limits
-- `cv <voltage>` - Set constant voltage mode
-- `cc <current>` - Set constant current mode
 - `on` - Turn output ON
 - `off` - Turn output OFF
-- `lock` - Lock keypad
-- `unlock` - Unlock keypad
-- `status` - Read current status
+- `set V I` - Set voltage (V) and current (I)
+- `status` - Display current status
+- `info` - Display device information
+- `config` - Display current configuration
+- `save` - Save current config to NVS
+- `reset` - Reset config to defaults
+- `help` - Show help message
 
-## Supported Registers
+### Memory Group Commands
 
-The library supports all major registers of the XY-SK120, including:
+- `mem N` - Display memory group N (0-9)
+- `call N` - Call memory group N (1-9) to active memory
+- `save2mem N` - Save current settings to memory group N (1-9)
+- `setmem N param value` - Set specific parameter in memory group N
+  - Parameters: v(voltage), i(current), p(power), ovp, ocp, opp, oah, owh, uvp, ucp
 
-- Basic control registers (voltage, current, power)
-- Protection settings (OVP, OCP, OPP, OTP)
-- System settings (brightness, lock, buzzer)
-- Measurement registers (temperature, input voltage)
-- Energy meters (amp-hours, watt-hours)
+### Debug Commands
 
-## Implementation Details
+The project supports direct register access for debugging and advanced usage:
 
-### Modbus Register Mapping
+- `read addr count` - Read 'count' registers starting at address 'addr'
+- `write addr value` - Write 'value' to register at address 'addr'
+- `writes addr v1 v2 ...` - Write multiple values to consecutive registers
 
-The library maps all known Modbus registers from the XY-SK120 documentation. Here's a comprehensive overview of implemented registers and their corresponding library methods:
+Examples:
+- `read 0x0000 1` - Read the voltage setting register (result shows different scaling factors)
+- `write 0x0000 1250` - Set voltage to 12.50V (1250/100)
+- `read 0x0002 3` - Read output voltage, current, and power
 
-| Register Address | Description | Data Type | Unit | Library Methods |
-|------------------|-------------|-----------|------|----------------|
-| 0x0000 (REG_V_SET) | Voltage setting | WORD | V (2 decimal) | `setVoltage()`, `setVoltageAndCurrent()` |
-| 0x0001 (REG_I_SET) | Current setting | WORD | A (3 decimal) | `setCurrent()`, `setVoltageAndCurrent()` |
-| 0x0002 (REG_VOUT) | Output voltage display | WORD | V (2 decimal) | Read via `getOutput()`, `getOutputStatus()` |
-| 0x0003 (REG_IOUT) | Output current display | WORD | A (3 decimal) | Read via `getOutput()`, `getOutputStatus()` |
-| 0x0004 (REG_POWER) | Output power display | WORD | W (2 decimal) | Read via `getOutput()`, `getOutputStatus()` |
-| 0x0005 (REG_UIN) | Input voltage display | WORD | V (2 decimal) | `getInputVoltage()` |
-| 0x0006/0x0007 (REG_AH_LOW/HIGH) | Amp-hour counter | DWORD | mAh | `getAmpHours()` |
-| 0x0008/0x0009 (REG_WH_LOW/HIGH) | Watt-hour counter | DWORD | mWh | `getWattHours()` |
-| 0x000A/B/C (REG_OUT_H/M/S) | Output time | 3×WORD | h/min/s | `getOutputTime()` |
-| 0x000D (REG_T_IN) | Internal temperature | WORD | °C/°F (1 decimal) | `getInternalTemperature()` |
-| 0x000E (REG_T_EX) | External temperature | WORD | °C/°F (1 decimal) | `getExternalTemperature()` |
-| 0x000F (REG_LOCK) | Key lock status | WORD | 0/1 | `setKeyLock()` |
-| 0x0010 (REG_PROTECT) | Protection status | WORD | Bits | `readProtectionStatus()` |
-| 0x0011 (REG_CVCC) | CC/CV mode status | WORD | 0/1 | `isInConstantCurrentMode()`, `isInConstantVoltageMode()` |
-| 0x0012 (REG_ONOFF) | Output on/off status | WORD | 0/1 | `setOutputState()`, `turnOutputOn()`, `turnOutputOff()` |
-| 0x0013 (REG_F_C) | Temperature unit | WORD | 0/1 (°C/°F) | `setTemperatureUnit()`, `getTemperatureUnit()` |
-| 0x0014 (REG_B_LED) | Backlight brightness | WORD | 0-5 | `setBacklightBrightness()` |
-| 0x0015 (REG_SLEEP) | Sleep timeout | WORD | min | `setSleepTimeout()` |
-| 0x0016 (REG_MODEL) | Model number | WORD | - | `readModel()` |
-| 0x0017 (REG_VERSION) | Firmware version | WORD | - | `readVersion()` |
-| 0x0018 (REG_SLAVE_ADDR) | Modbus slave address | WORD | 1-247 | `setSlaveAddress()` |
-| 0x0019 (REG_BAUDRATE_L) | Baud rate setting | WORD | 0-8 | `readBaudRate()`, `setBaudRate()` |
-| 0x001A (REG_T_IN_CAL) | Internal temp. calib. | WORD | °C/°F (1 decimal) | `setInternalTempCalibration()` |
-| 0x001B (REG_T_EXT_CAL) | External temp. calib. | WORD | °C/°F (1 decimal) | `setExternalTempCalibration()` |
-| 0x001C (REG_BUZZER) | Buzzer enable | WORD | 0/1 | `setBuzzer()` |
-| 0x001D (REG_EXTRACT_M) | Data group selection | WORD | 0-9 | `selectDataGroup()` |
-| 0x001E (REG_SYS_STATUS) | System status | WORD | Bits | `readSystemStatus()` |
-| 0x0050 (REG_CV_SET) | Constant voltage setting | WORD | V (2 decimal) | `setConstantVoltage()`, `getConstantVoltage()` |
-| 0x0051 (REG_CC_SET) | Constant current setting | WORD | A (3 decimal) | `setConstantCurrent()`, `getConstantCurrent()` |
-| 0x0052 (REG_S_VLP) | Under voltage protection | WORD | V (2 decimal) | `setUnderVoltageProtection()`, `getUnderVoltageProtection()` |
-| 0x0053 (REG_S_OVP) | Over voltage protection | WORD | V (2 decimal) | `setOverVoltageProtection()`, `getOverVoltageProtection()` |
-| 0x0054 (REG_S_OCP) | Over current protection | WORD | A (3 decimal) | `setOverCurrentProtection()`, `getOverCurrentProtection()` |
-| 0x0055 (REG_S_OPP) | Over power protection | WORD | W (2 decimal) | `setOverPowerProtection()`, `getOverPowerProtection()` |
-| 0x0056/57 (REG_S_OHP_H/M) | High power protection time | 2×WORD | h/min | `setHighPowerProtectionTime()`, `getHighPowerProtectionTime()` |
-| 0x0058/59 (REG_S_OAH_L/H) | Over amp-hour protect. | 2×WORD | mAh | `setOverAmpHourProtection()`, `getOverAmpHourProtection()` |
-| 0x005A/5B (REG_S_OWH_L/H) | Over watt-hour protect. | 2×WORD | 10mWh | `setOverWattHourProtection()`, `getOverWattHourProtection()` |
-| 0x005C (REG_S_OTP) | Over temperature protect. | WORD | °C/°F (1 decimal) | `setOverTemperatureProtection()`, `getOverTemperatureProtection()` |
-| 0x005D (REG_S_INI) | Power-on initialization | WORD | 0/1 | `setPowerOnInitialization()`, `getPowerOnInitialization()` |
+Addresses can be provided in decimal or hexadecimal (with 0x prefix).
 
-### OSD Menu Mapping to Library Functions
+## Register Map
 
-The XY-SK120 has an On-Screen Display (OSD) with various settings. Here's how these map to library functions:
+The power supply uses the following register map (partial list):
 
-| OSD Menu Item | Description | Library Method |
-|---------------|-------------|----------------|
-| SET V | Set voltage | `setVoltage()` |
-| SET I | Set current | `setCurrent()` |
-| SET | Both V and I at once | `setVoltageAndCurrent()` |
-| CV | Constant voltage mode | `setConstantVoltage()` |
-| CC | Constant current mode | `setConstantCurrent()` |
-| M-SET | Memory preset (data group) | `selectDataGroup()` |
-| OVP | Over-voltage protection | `setOverVoltageProtection()` |
-| OCP | Over-current protection | `setOverCurrentProtection()` |
-| OPP | Over-power protection | `setOverPowerProtection()` |
-| UVP | Under-voltage protection | `setUnderVoltageProtection()` |
-| OTP | Over-temperature protection | `setOverTemperatureProtection()` |
-| OAH | Over amp-hour protection | `setOverAmpHourProtection()` |
-| OWH | Over watt-hour protection | `setOverWattHourProtection()` |
-| OHP | Over high-power time protection | `setHighPowerProtectionTime()` |
-| POW | Power-on state | `setPowerOnInitialization()` |
-| KEY | Key lock | `setKeyLock()` |
-| BKL | Backlight brightness | `setBacklightBrightness()` |
-| BUZ | Buzzer | `setBuzzer()` |
-| TUN | Temperature unit (°C/°F) | `setTemperatureUnit()` |
-| SLP | Sleep timeout | `setSleepTimeout()` |
-| ADR | Modbus address | `setSlaveAddress()` |
-| BAD | Baud rate | `setBaudRate()` |
+| Address | Description | Unit | Scaling | R/W |
+|---------|-------------|------|---------|-----|
+| 0x0000  | Voltage setting | V | /100 | R/W |
+| 0x0001  | Current setting | A | /1000 | R/W |
+| 0x0002  | Output voltage | V | /100 | R |
+| 0x0003  | Output current | A | /1000 | R |
+| 0x0004  | Output power | W | /100 | R |
+| 0x0012  | Output on/off | 0/1 | - | R/W |
 
-### Unimplemented/Undocumented Features
+For a more complete register map, see the XY-SKxxx library documentation.
 
-Some registers and features are not fully implemented because they are:
-1. Undocumented in the available Modbus specification
-2. Related to specialized hardware add-ons (e.g., WiFi module, RTC)
-3. System-level functions requiring additional research
+## Building
 
-These include:
-- Registers 0x0030-0x0034 (related to Sinilink ESP8285H16 module)
-- Registers 0x0100-0x0103 (RTC settings)
-- Registers 0x0110-0x011D (weather information)
-- Calibration functions (Zero, CLU, CLA)
-- Factory reset function
-- MPPT solar charging settings
+This project uses PlatformIO. To build and upload:
 
-## Timing Considerations
-
-The library implements specific timing controls for Modbus RTU communication:
-- Silent interval calculations based on baud rate
-- Pre-transmission and post-transmission handlers
-- Retry mechanisms for improved reliability
-- Proper command sequencing with appropriate delays
-
-These timing controls ensure reliable communication with the device following the Modbus RTU specification.
-
-## Limitations
-
-- Only tested with XY-SK120 model. May work with other XY-SK series models.
-- Not all registers are fully documented or implemented.
-- Some advanced features like data logging, calibration, etc. are not implemented.
-
-## Troubleshooting
-
-- **No communication:** Check baud rate, wiring, and slave ID
-- **Erratic behavior:** Ensure proper timing between commands (library handles this internally)
-- **Protection trips:** Check your protection settings and load conditions
-- **Configuration issues:** Make sure XY-SKxxx_Config.h is included in your project and the pins match your hardware
-
-## Contributing
-
-Contributions are welcome! Please feel free to submit a Pull Request.
+```
+pio run -t upload
+```
 
 ## License
 
-This project is licensed under the MIT License - see the LICENSE file for details.
-
-## Acknowledgments
-
-- Based on ModbusMaster library by Doc Walker
-- Inspired by the need for better control of the XY-SK120 module
+[MIT License](LICENSE)

--- a/documentation/Data Group (Press VSET To rotate paramet.md
+++ b/documentation/Data Group (Press VSET To rotate paramet.md
@@ -1,0 +1,14 @@
+Data Group (Press VSET To rotate parameters)
+
+CU  constant voltage (v)
+CC  constant current (a)
+LVP low voltage protection (v)
+OUP over voltage protection (v)
+OCP over current protection (a)
+OPP over power protection (W)
+OAH over ampere protection hour (Ah)
+OPH over power protection hour (Wh)
+OHP over hour protection (h)
+ORP over tempreture protection (c/f)
+ERP 
+PON

--- a/lib/XY-SKxxx/README.md
+++ b/lib/XY-SKxxx/README.md
@@ -12,6 +12,7 @@ This library provides a complete interface to the XY-SK series digital power sup
 - Set constant voltage (CV) or constant current (CC) modes
 - Configure protection settings (OVP, OCP, OPP, OTP, etc.)
 - Read and control device status (keypad lock, brightness, etc.)
+- Direct register access for debugging
 
 ## Installation
 
@@ -192,6 +193,52 @@ powerSupply.setBacklightBrightness(3);
 // Set sleep timeout in minutes
 powerSupply.setSleepTimeout(5);
 ```
+
+### Memory Group Access
+
+The library supports accessing memory groups (M0-M9) for storing and recalling device settings:
+
+```cpp
+// Call a memory group (activate it)
+powerSupply.callMemoryGroup(xy_sk::MemoryGroup::M1);
+
+// Read from a memory group
+uint16_t data[xy_sk::DATA_GROUP_REGISTERS];
+powerSupply.readMemoryGroup(xy_sk::MemoryGroup::M2, data);
+
+// Write to a memory group
+powerSupply.writeMemoryGroup(xy_sk::MemoryGroup::M3, data);
+```
+
+### Debug Register Access
+
+For advanced users and debugging purposes, the library provides direct register access methods:
+
+```cpp
+// Read registers directly
+uint16_t values[10];
+powerSupply.debugReadRegisters(0x0000, 10, values);  // Read 10 registers starting at 0x0000
+
+// Write to a register directly
+powerSupply.debugWriteRegister(0x0000, 1250);  // Write 1250 (12.50V) to voltage register
+
+// Write to multiple registers
+uint16_t writeValues[2] = {1250, 2000};  // 12.50V, 2.000A
+powerSupply.debugWriteRegisters(0x0000, 2, writeValues);  // Write to voltage and current registers
+```
+
+## Serial Monitor Interface
+
+When used with the project's serial monitor interface, you can use these debug commands:
+
+- `read addr count` - Read 'count' registers starting at address 'addr'
+- `write addr value` - Write 'value' to register at address 'addr'
+- `writes addr v1 v2 ...` - Write multiple values to consecutive registers
+
+Examples:
+- `read 0x0000 1` - Read the voltage setting register
+- `write 0x0000 1250` - Set voltage to 12.50V (1250/100)
+- `read 0x0002 3` - Read output voltage, current, and power
 
 ## Cache System
 

--- a/lib/XY-SKxxx/XY-SKxxx-cd-data-group.cpp
+++ b/lib/XY-SKxxx/XY-SKxxx-cd-data-group.cpp
@@ -1,0 +1,26 @@
+#include "XY-SKxxx-cd-data-group.h"
+
+namespace xy_sk {
+
+uint16_t DataGroupManager::getGroupStartAddress(MemoryGroup group) {
+    // Calculate the starting address based on the formula: 0050H + group_number * 0010H
+    return DATA_GROUP_BASE_ADDR + (static_cast<uint16_t>(group) * DATA_GROUP_SIZE);
+}
+
+uint16_t DataGroupManager::getRegisterAddress(MemoryGroup group, uint8_t offset) {
+    // Ensure offset is within valid range (0-13)
+    if (offset >= DATA_GROUP_REGISTERS) {
+        // Invalid offset, return base address as fallback
+        return getGroupStartAddress(group);
+    }
+    
+    // Calculate register address: base address + offset
+    return getGroupStartAddress(group) + offset;
+}
+
+uint16_t DataGroupManager::getRegisterAddress(MemoryGroup group, GroupRegisterOffset regOffset) {
+    // Convert the enum to its underlying type (uint8_t)
+    return getRegisterAddress(group, static_cast<uint8_t>(regOffset));
+}
+
+} // namespace xy_sk

--- a/lib/XY-SKxxx/XY-SKxxx-cd-data-group.h
+++ b/lib/XY-SKxxx/XY-SKxxx-cd-data-group.h
@@ -1,0 +1,171 @@
+#ifndef XY_SKXXX_CD_DATA_GROUP_H
+#define XY_SKXXX_CD_DATA_GROUP_H
+
+#include <stdint.h>
+
+namespace xy_sk {
+
+// Constants for data group configuration
+constexpr uint16_t DATA_GROUP_BASE_ADDR = 0x0050;     // M0 starting address (0050H)
+constexpr uint16_t DATA_GROUP_SIZE = 0x0010;          // 16 bytes per group (14 registers used)
+constexpr uint16_t DATA_GROUP_REGISTERS = 14;         // Number of registers in each group
+constexpr uint16_t EXTRACT_M_REGISTER = 0x001D;       // Register to call memory groups
+
+// Memory Group Register Offsets (from the base address of each memory group)
+enum class GroupRegisterOffset : uint8_t {
+    VOLTAGE_SET      = 0x00, // 0x0050: Set voltage value
+    CURRENT_SET      = 0x01, // 0x0051: Set current value
+    POWER_SET        = 0x02, // 0x0052: Set power value
+    OVP_SET          = 0x03, // 0x0053: Over voltage protection value
+    OCP_SET          = 0x04, // 0x0054: Over current protection value
+    OPP_SET          = 0x05, // 0x0055: Over power protection value
+    OAH_SET          = 0x06, // 0x0056: Over amp-hour protection value
+    OWH_SET          = 0x07, // 0x0057: Over watt-hour protection value
+    UVP_SET          = 0x08, // 0x0058: Under voltage protection value
+    UCP_SET          = 0x09, // 0x0059: Under current protection value
+    VOLTAGE_BACK     = 0x0A, // 0x005A: Back to preset voltage value
+    CURRENT_BACK     = 0x0B, // 0x005B: Back to preset current value
+    POWER_BACK       = 0x0C, // 0x005C: Back to preset power value
+    PARAMETERS       = 0x0D  // 0x005D: Parameter settings (bit flags)
+};
+
+// Enum for memory groups
+enum class MemoryGroup {
+    M0 = 0,
+    M1 = 1,
+    M2 = 2,
+    M3 = 3,
+    M4 = 4,
+    M5 = 5,
+    M6 = 6,
+    M7 = 7,
+    M8 = 8,
+    M9 = 9
+};
+
+// Structure to hold the data for a single memory group
+struct MemoryGroupData {
+    uint16_t values[DATA_GROUP_REGISTERS];
+    bool valid;
+    unsigned long lastUpdate;
+};
+
+class DataGroupManager {
+public:
+    /**
+     * Calculate the starting address for a given memory group
+     * 
+     * @param group Memory group (M0-M9)
+     * @return Starting register address for the memory group
+     */
+    static uint16_t getGroupStartAddress(MemoryGroup group);
+    
+    /**
+     * Calculate the address for a specific register within a memory group
+     * 
+     * @param group Memory group (M0-M9)
+     * @param offset Register offset within the group (0-13)
+     * @return Register address
+     */
+    static uint16_t getRegisterAddress(MemoryGroup group, uint8_t offset);
+    
+    /**
+     * Get the address for a specific register within a memory group
+     * 
+     * @param group Memory group (M0-M9)
+     * @param regOffset Specific register offset from GroupRegisterOffset enum
+     * @return Register address
+     */
+    static uint16_t getRegisterAddress(MemoryGroup group, GroupRegisterOffset regOffset);
+    
+    /**
+     * Call a memory group to make it active (copy to M0)
+     * This writes to the EXTRACT_M register
+     * 
+     * @param group Memory group to call (M1-M9, M0 is ignored)
+     * @param modbusWrite Function to write to Modbus register
+     * @return true if successful
+     */
+    template<typename WriteFunc>
+    static bool callMemoryGroup(MemoryGroup group, WriteFunc modbusWrite) {
+        // M0 is already active, no need to call it
+        if (group == MemoryGroup::M0) {
+            return true;
+        }
+        
+        // Write memory group number to EXTRACT_M register (001DH)
+        return modbusWrite(EXTRACT_M_REGISTER, static_cast<uint16_t>(group));
+    }
+    
+    /**
+     * Read all registers from a memory group
+     * 
+     * @param group Memory group to read from
+     * @param data Array to store the read data (must be able to hold DATA_GROUP_REGISTERS values)
+     * @param modbusReadMultiple Function to read multiple Modbus registers
+     * @return true if successful
+     */
+    template<typename ReadFunc>
+    static bool readMemoryGroup(MemoryGroup group, uint16_t* data, ReadFunc modbusReadMultiple) {
+        uint16_t startAddr = getGroupStartAddress(group);
+        return modbusReadMultiple(startAddr, DATA_GROUP_REGISTERS, data);
+    }
+    
+    /**
+     * Write all registers to a memory group
+     * 
+     * @param group Memory group to write to
+     * @param data Array containing the data to write (must contain DATA_GROUP_REGISTERS values)
+     * @param modbusWriteMultiple Function to write multiple Modbus registers
+     * @return true if successful
+     */
+    template<typename WriteFunc>
+    static bool writeMemoryGroup(MemoryGroup group, const uint16_t* data, WriteFunc modbusWriteMultiple) {
+        uint16_t startAddr = getGroupStartAddress(group);
+        return modbusWriteMultiple(startAddr, DATA_GROUP_REGISTERS, data);
+    }
+    
+    /**
+     * Read a specific register from a memory group
+     * 
+     * @param group Memory group to read from
+     * @param regOffset Specific register offset from GroupRegisterOffset enum
+     * @param value Reference to store the read value
+     * @param modbusRead Function to read a Modbus register
+     * @return true if successful
+     */
+    template<typename ReadFunc>
+    static bool readGroupRegister(MemoryGroup group, GroupRegisterOffset regOffset, uint16_t& value, ReadFunc modbusRead) {
+        uint16_t addr = getRegisterAddress(group, regOffset);
+        return modbusRead(addr, value);
+    }
+    
+    /**
+     * Write to a specific register in a memory group
+     * 
+     * @param group Memory group to write to
+     * @param regOffset Specific register offset from GroupRegisterOffset enum
+     * @param value Value to write
+     * @param modbusWrite Function to write to a Modbus register
+     * @return true if successful
+     */
+    template<typename WriteFunc>
+    static bool writeGroupRegister(MemoryGroup group, GroupRegisterOffset regOffset, uint16_t value, WriteFunc modbusWrite) {
+        uint16_t addr = getRegisterAddress(group, regOffset);
+        return modbusWrite(addr, value);
+    }
+};
+
+} // namespace xy_sk
+
+// Now add methods to the XY_SKxxx class for memory group interactions with caching
+class XY_SKxxx;  // Forward declaration
+
+// Add these method declarations to XY_SKxxx.h
+// bool readMemoryGroup(xy_sk::MemoryGroup group, uint16_t* data, bool force = false);
+// bool writeMemoryGroup(xy_sk::MemoryGroup group, const uint16_t* data);
+// bool callMemoryGroup(xy_sk::MemoryGroup group);
+// bool getCachedMemoryGroup(xy_sk::MemoryGroup group, uint16_t* data, bool refresh = false);
+// bool updateMemoryGroupCache(xy_sk::MemoryGroup group, bool force = false);
+
+#endif // XY_SKXXX_CD_DATA_GROUP_H

--- a/lib/XY-SKxxx/XY-SKxxx-protection.cpp
+++ b/lib/XY-SKxxx/XY-SKxxx-protection.cpp
@@ -1,14 +1,20 @@
 #include "XY-SKxxx-internal.h"
 #include "XY-SKxxx.h"
 
-/* Protection settings methods */
+// Basic protection thresholds
 bool XY_SKxxx::setOverVoltageProtection(float voltage) {
   uint16_t voltageValue = (uint16_t)(voltage * 100);
   waitForSilentInterval();
-  preTransmission();
-  uint8_t result = node.writeSingleRegister(REG_S_OVP, voltageValue);
-  postTransmission();
-  return (result == node.ku8MBSuccess);
+  
+  uint8_t result = modbus.writeSingleRegister(REG_S_OVP, voltageValue);
+  _lastCommsTime = millis();
+  
+  if (result == modbus.ku8MBSuccess) {
+    _protection.overVoltageProtection = voltage;
+    return true;
+  }
+  
+  return false;
 }
 
 bool XY_SKxxx::getOverVoltageProtection(float &voltage) {

--- a/lib/XY-SKxxx/XY-SKxxx-read-write-registers.cpp
+++ b/lib/XY-SKxxx/XY-SKxxx-read-write-registers.cpp
@@ -1,0 +1,89 @@
+#include "XY-SKxxx-internal.h"
+#include "XY-SKxxx.h"
+
+/**
+ * Debug function to read directly from a register
+ * 
+ * @param addr Register address to read from
+ * @param count Number of registers to read (1-125)
+ * @param values Array to store the read values (must be at least 'count' in size)
+ * @return true if successful
+ */
+bool XY_SKxxx::debugReadRegisters(uint16_t addr, uint8_t count, uint16_t* values) {
+  if (count < 1 || count > 125) {
+    return false; // Invalid count value
+  }
+  
+  waitForSilentInterval();
+  
+  // Try to read holding registers first
+  uint8_t result = modbus.readHoldingRegisters(addr, count);
+  
+  if (result == modbus.ku8MBSuccess) {
+    // Copy the results to the output array
+    for (uint8_t i = 0; i < count; i++) {
+      values[i] = modbus.getResponseBuffer(i);
+    }
+    _lastCommsTime = millis();
+    return true;
+  }
+  
+  // If holding registers fail, try input registers
+  delay(_silentIntervalTime * 2);
+  result = modbus.readInputRegisters(addr, count);
+  
+  if (result == modbus.ku8MBSuccess) {
+    // Copy the results to the output array
+    for (uint8_t i = 0; i < count; i++) {
+      values[i] = modbus.getResponseBuffer(i);
+    }
+    _lastCommsTime = millis();
+    return true;
+  }
+  
+  _lastCommsTime = millis();
+  return false;
+}
+
+/**
+ * Debug function to write directly to a register
+ * 
+ * @param addr Register address to write to
+ * @param value Value to write
+ * @return true if successful
+ */
+bool XY_SKxxx::debugWriteRegister(uint16_t addr, uint16_t value) {
+  waitForSilentInterval();
+  
+  uint8_t result = modbus.writeSingleRegister(addr, value);
+  _lastCommsTime = millis();
+  
+  return (result == modbus.ku8MBSuccess);
+}
+
+/**
+ * Debug function to write to multiple consecutive registers
+ * 
+ * @param addr Starting register address
+ * @param count Number of registers to write (1-123)
+ * @param values Array of values to write (must be at least 'count' in size)
+ * @return true if successful
+ */
+bool XY_SKxxx::debugWriteRegisters(uint16_t addr, uint8_t count, const uint16_t* values) {
+  if (count < 1 || count > 123) {
+    return false; // Invalid count value
+  }
+  
+  waitForSilentInterval();
+  
+  // Set the transmit buffer with the values to write
+  for (uint8_t i = 0; i < count; i++) {
+    modbus.setTransmitBuffer(i, values[i]);
+  }
+  
+  // Write the values to the registers
+  uint8_t result = modbus.writeMultipleRegisters(addr, count);
+  _lastCommsTime = millis();
+  
+  return (result == modbus.ku8MBSuccess);
+}

--- a/lib/XY-SKxxx/XY-SKxxx.h
+++ b/lib/XY-SKxxx/XY-SKxxx.h
@@ -61,30 +61,24 @@
 #define REG_CV_SET         0x0050    // CV (constant voltage) setting, 2 bytes, 2 decimal places, unit: V, Read and Write
 #define REG_CC_SET         0x0051    // CC (constant current) setting, 2 bytes, 3 decimal places, unit: A, Read and Write
 
-// done
 #define REG_S_VLP          0x0052    // LVP (input under voltage protection) setting, 2 bytes, 2 decimal places, unit: W, Read and Write
 #define REG_S_OVP          0x0053    // OVP (output over voltage protection) setting, 2 bytes, 2 decimal places, unit: V, Read and Write
 
-//done
 #define REG_S_OCP          0x0054    // OCP (output over current protection) setting, 2 bytes, 3 decimal places, unit: A, Read and Write
 #define REG_S_OPP          0x0055    // OPP (output over power protection) setting, 2 bytes, 2 decimal places, unit: W, Read and Write
 
-// done
 #define REG_S_OHP_H        0x0056    // OHP_H (output high power protection - hours) setting, 2 bytes, 0 decimal places, unit: h, Read and Write
 #define REG_S_OHP_M        0x0057    // OHP_M (output high power protection - minutes) setting, 2 bytes, 0 decimal places, unit: min, Read and Write
 
-// done
 #define REG_S_OAH_L        0x0058    // OAH_LOW (over-amp-hour protection - low) setting, 2 bytes, 0 decimal places, unit: mAh, Read and Write
 #define REG_S_OAH_H        0x0059    // OAH_HIGH (over-amp-hour protection - high) setting, 2 bytes, 0 decimal places, unit: mAh, Read and Write
 
-// done
 #define REG_S_OWH_L        0x005A    // OWH_LOW (over-watt-hour protection - low) setting, 2 bytes, 0 decimal places, unit: 10mWh, Read and Write
 #define REG_S_OWH_H        0x005B    // OWH_HIGH (over-watt-hour protection - high) setting, 2 bytes, 0 decimal places, unit: 10mWh, Read and Write
 
-// done
 #define REG_S_OTP          0x005C   // Over temperature protection setting, 2 bytes, 1 decimal place, unit: °F / °C, Read and Write
 
-#define REG_S_INI          0x005D    // WIP: Power-on initialization setting, 2 bytes, 0 decimal places, unit: 0/1 (0: output off upon power on, 1: output on upon power on), Read and Write
+#define REG_S_INI          0x005D    // Power-on initialization setting, 2 bytes, 0 decimal places, unit: 0/1 (0: output off upon power on, 1: output on upon power on), Read and Write
 
 // Additional Modbus register addresses for XY-SK120 0x0100 - 0x0103, will not implement these as it's related to RTC (Real Time Clock) settings
 
@@ -315,10 +309,23 @@ public:
   bool setProtectionStatus(uint16_t status);
   bool setSystemStatus(uint16_t status);
 
+  // Add direct register access methods for memory groups
+  bool readRegisters(uint16_t addr, uint16_t count, uint16_t* buffer);
+  bool writeRegister(uint16_t addr, uint16_t value);
+  bool writeRegisters(uint16_t addr, uint16_t count, uint16_t* buffer);
+
+  // Make ModbusMaster available to external code
+  ModbusMaster modbus;
+
+  // Debug functions for direct register access
+  bool debugReadRegisters(uint16_t addr, uint8_t count, uint16_t* values);
+  bool debugWriteRegister(uint16_t addr, uint16_t value);
+  bool debugWriteRegisters(uint16_t addr, uint8_t count, const uint16_t* values);
+
 private:
   uint8_t _rxPin;
   uint8_t _txPin;
-  ModbusMaster node;
+  // ModbusMaster node; // Changed to public modbus
   uint8_t _slaveID;
   unsigned long _baudRate;
   unsigned long _lastCommsTime;

--- a/src/serial_monitor_interface.cpp
+++ b/src/serial_monitor_interface.cpp
@@ -2,6 +2,7 @@
 #include "XY-SKxxx.h"
 #include "XY-SKxxx_Config.h"
 #include "serial_monitor_interface.h"
+#include "XY-SKxxx-cd-data-group.h"
 
 // Helper function to display device status
 void displayStatus(XY_SKxxx* powerSupply) {
@@ -41,6 +42,127 @@ void displayConfig(XYModbusConfig &config) {
   Serial.println("------------------------");
 }
 
+// Helper function to display a memory group's settings
+void displayMemoryGroup(XY_SKxxx* powerSupply, xy_sk::MemoryGroup group) {
+  uint16_t data[xy_sk::DATA_GROUP_REGISTERS];
+  
+  if (xy_sk::DataGroupManager::readMemoryGroup(
+        group,
+        data,
+        [powerSupply](uint16_t addr, uint16_t count, uint16_t* buffer) -> bool {
+          return powerSupply->readRegisters(addr, count, buffer);
+        })) {
+    
+    Serial.print("\n----- MEMORY GROUP M");
+    Serial.print(static_cast<int>(group));
+    Serial.println(" -----");
+    
+    // 0x0050: CV (constant voltage) setting
+    Serial.print("Voltage Set:       "); 
+    Serial.print(data[static_cast<uint8_t>(xy_sk::GroupRegisterOffset::VOLTAGE_SET)] / 100.0f, 2);
+    Serial.println(" V   (Constant Voltage Setting)");
+    
+    // 0x0051: CC (constant current) setting
+    Serial.print("Current Set:       "); 
+    Serial.print(data[static_cast<uint8_t>(xy_sk::GroupRegisterOffset::CURRENT_SET)] / 1000.0f, 3);
+    Serial.println(" A   (Constant Current Setting)");
+    
+    // 0x0052: LVP (input under voltage protection) setting
+    Serial.print("UVP Value:         "); 
+    Serial.print(data[static_cast<uint8_t>(xy_sk::GroupRegisterOffset::UVP_SET)] / 100.0f, 2);
+    Serial.println(" V   (Under Voltage Protection)");
+    
+    // 0x0053: OVP (output over voltage protection) setting
+    Serial.print("OVP Value:         "); 
+    Serial.print(data[static_cast<uint8_t>(xy_sk::GroupRegisterOffset::OVP_SET)] / 100.0f, 2);
+    Serial.println(" V   (Over Voltage Protection)");
+    
+    // 0x0054: OCP (output over current protection) setting
+    Serial.print("OCP Value:         "); 
+    Serial.print(data[static_cast<uint8_t>(xy_sk::GroupRegisterOffset::OCP_SET)] / 1000.0f, 3);
+    Serial.println(" A   (Over Current Protection)");
+    
+    // 0x0055: OPP (output over power protection) setting
+    Serial.print("OPP Value:         "); 
+    Serial.print(data[static_cast<uint8_t>(xy_sk::GroupRegisterOffset::OPP_SET)] / 10.0f, 1);
+    Serial.println(" W   (Over Power Protection)");
+    
+    // 0x0056: OAH (over-amp-hour protection - hours)
+    Serial.print("OAH Hours:         "); 
+    Serial.print(data[static_cast<uint8_t>(xy_sk::GroupRegisterOffset::OAH_SET)]);
+    Serial.println(" h   (Over Amp-Hour Protection - Hours)");
+    
+    // 0x0057: OAH (over-amp-hour protection - minutes)
+    Serial.print("OAH Minutes:       "); 
+    Serial.print(data[static_cast<uint8_t>(xy_sk::GroupRegisterOffset::OWH_SET)]);
+    Serial.println(" min (Over Amp-Hour Protection - Minutes)");
+    
+    // 0x0058: OAH_LOW (over-amp-hour protection - low)
+    Serial.print("OAH Low Value:     "); 
+    Serial.print(data[static_cast<uint8_t>(xy_sk::GroupRegisterOffset::UVP_SET)]);
+    Serial.println(" mAh (Over Amp-Hour Protection Low Bytes)");
+    
+    // 0x0059: OAH_HIGH (over-amp-hour protection - high)
+    Serial.print("OAH High Value:    "); 
+    Serial.print(data[static_cast<uint8_t>(xy_sk::GroupRegisterOffset::UCP_SET)]);
+    Serial.println(" mAh (Over Amp-Hour Protection High Bytes)");
+    
+    // 0x005A: OWH_LOW (over-watt-hour protection - low)
+    Serial.print("OWH Low Value:     "); 
+    Serial.print(data[static_cast<uint8_t>(xy_sk::GroupRegisterOffset::VOLTAGE_BACK)] * 10);
+    Serial.println(" mWh (Over Watt-Hour Protection Low Bytes)");
+    
+    // 0x005B: OWH_HIGH (over-watt-hour protection - high)
+    Serial.print("OWH High Value:    "); 
+    Serial.print(data[static_cast<uint8_t>(xy_sk::GroupRegisterOffset::CURRENT_BACK)] * 10);
+    Serial.println(" mWh (Over Watt-Hour Protection High Bytes)");
+    
+    // 0x005C: Over temperature protection setting
+    Serial.print("OTP Value:         "); 
+    // Fix: Changed divisor from 10.0f to 1.0f to display correct temperature
+    Serial.print(data[static_cast<uint8_t>(xy_sk::GroupRegisterOffset::POWER_BACK)], 0);
+    Serial.println(" °C  (Over Temperature Protection)");
+    
+    // 0x005D: Power-on initialization setting
+    uint16_t iniValue = data[static_cast<uint8_t>(xy_sk::GroupRegisterOffset::PARAMETERS)];
+    Serial.print("Power-On Setting:  "); 
+    Serial.print(iniValue);
+    Serial.print("    (");
+    Serial.print(iniValue == 0 ? "Output OFF" : "Output ON");
+    Serial.println(" at power-up)");
+    
+    Serial.println("------------------------");
+  } else {
+    Serial.print("Failed to read memory group M");
+    Serial.println(static_cast<int>(group));
+  }
+}
+
+// Helper function to read current settings and save to specified memory group
+bool saveCurrentToMemoryGroup(XY_SKxxx* powerSupply, xy_sk::MemoryGroup targetGroup) {
+  // First read M0 (current settings)
+  uint16_t data[xy_sk::DATA_GROUP_REGISTERS];
+  
+  if (!xy_sk::DataGroupManager::readMemoryGroup(
+        xy_sk::MemoryGroup::M0,
+        data,
+        [powerSupply](uint16_t addr, uint16_t count, uint16_t* buffer) -> bool {
+          // Use the new readRegisters method
+          return powerSupply->readRegisters(addr, count, buffer);
+        })) {
+    return false;
+  }
+  
+  // Then write to target memory group
+  return xy_sk::DataGroupManager::writeMemoryGroup(
+    targetGroup,
+    data,
+    [powerSupply](uint16_t addr, uint16_t count, const uint16_t* buffer) -> bool {
+      // Use the new writeRegisters method
+      return powerSupply->writeRegisters(addr, count, const_cast<uint16_t*>(buffer));
+    });
+}
+
 void printHelp() {
   Serial.println("\nAvailable Commands:");
   Serial.println("  on         - Turn output ON");
@@ -52,6 +174,57 @@ void printHelp() {
   Serial.println("  save       - Save current config to NVS");
   Serial.println("  reset      - Reset config to defaults");
   Serial.println("  help       - Show this help message");
+  
+  // Add memory group commands
+  Serial.println("\nMemory Group Commands:");
+  Serial.println("  mem N       - Display memory group N (0-9)");
+  Serial.println("  call N      - Call memory group N (1-9) to active memory");
+  Serial.println("  save2mem N  - Save current settings to memory group N (1-9)");
+  Serial.println("  setmem N param value - Set specific parameter in memory group N");
+  Serial.println("                Parameters: v(voltage), i(current), p(power),");
+  Serial.println("                            ovp, ocp, opp, oah, owh, uvp, ucp");
+  
+  // Add debug commands
+  Serial.println("\nDebug Commands:");
+  Serial.println("  read addr count   - Read 'count' registers starting at address 'addr'");
+  Serial.println("  write addr value  - Write 'value' to register at address 'addr'");
+  Serial.println("  writes addr v1 v2 - Write multiple values to consecutive registers");
+}
+
+// Helper function to display register values in hex and decimal
+void displayRegisterValues(uint16_t startAddr, uint16_t* values, uint8_t count) {
+  Serial.println("\n----- REGISTER VALUES -----");
+  for (uint8_t i = 0; i < count; i++) {
+    uint16_t addr = startAddr + i;
+    uint16_t value = values[i];
+    
+    Serial.print("Addr 0x");
+    if (addr < 0x1000) Serial.print("0");
+    if (addr < 0x100) Serial.print("0");
+    if (addr < 0x10) Serial.print("0");
+    Serial.print(addr, HEX);
+    
+    Serial.print(": 0x");
+    if (value < 0x1000) Serial.print("0");
+    if (value < 0x100) Serial.print("0");
+    if (value < 0x10) Serial.print("0");
+    Serial.print(value, HEX);
+    
+    Serial.print(" (");
+    Serial.print(value, DEC);
+    Serial.print(") ");
+    
+    // Show as float with common scaling factors
+    Serial.print("Float: ");
+    Serial.print(value / 1000.0f, 3);
+    Serial.print(" / ");
+    Serial.print(value / 100.0f, 2);
+    Serial.print(" / ");
+    Serial.print(value / 10.0f, 1);
+    
+    Serial.println();
+  }
+  Serial.println("-------------------------");
 }
 
 void handleSerialCommand(String command, XY_SKxxx* powerSupply, XYModbusConfig &config) {
@@ -153,7 +326,6 @@ void handleSerialCommand(String command, XY_SKxxx* powerSupply, XYModbusConfig &
   else if (command.startsWith("baud ")) {
     uint32_t baud = command.substring(5).toInt();
     Serial.print("Setting baud rate to: "); Serial.println(baud);
-    config.baudRate = baud;
     displayConfig(config);
   }
   else if (command == "reload") {
@@ -176,14 +348,277 @@ void handleSerialCommand(String command, XY_SKxxx* powerSupply, XYModbusConfig &
       Serial.println("Connection test failed with new configuration");
     }
   }
+  // Memory group commands
+  else if (command.startsWith("mem ")) {
+    int groupNum = command.substring(4).toInt();
+    if (groupNum >= 0 && groupNum <= 9) {
+      xy_sk::MemoryGroup group = static_cast<xy_sk::MemoryGroup>(groupNum);
+      displayMemoryGroup(powerSupply, group);
+    } else {
+      Serial.println("Invalid memory group. Must be 0-9.");
+    }
+  }
+  else if (command.startsWith("call ")) {
+    int groupNum = command.substring(5).toInt();
+    if (groupNum >= 1 && groupNum <= 9) {
+      Serial.print("Calling memory group M");
+      Serial.println(groupNum);
+      
+      xy_sk::MemoryGroup group = static_cast<xy_sk::MemoryGroup>(groupNum);
+      bool success = xy_sk::DataGroupManager::callMemoryGroup(
+        group,
+        [powerSupply](uint16_t addr, uint16_t value) -> bool {
+          return powerSupply->writeRegister(addr, value);
+        });
+      
+      if (success) {
+        Serial.println("Memory group called successfully");
+        // Display the called memory group (Mn) instead of M0
+        displayMemoryGroup(powerSupply, group);
+      } else {
+        Serial.println("Failed to call memory group");
+      }
+    } else {
+      Serial.println("Invalid memory group. Must be 1-9.");
+    }
+  }
+  else if (command.startsWith("save2mem ")) {
+    int groupNum = command.substring(9).toInt();
+    if (groupNum >= 1 && groupNum <= 9) {
+      Serial.print("Saving current settings to memory group M");
+      Serial.println(groupNum);
+      
+      xy_sk::MemoryGroup group = static_cast<xy_sk::MemoryGroup>(groupNum);
+      if (saveCurrentToMemoryGroup(powerSupply, group)) {
+        Serial.println("Settings saved to memory group successfully");
+      } else {
+        Serial.println("Failed to save settings to memory group");
+      }
+    } else {
+      Serial.println("Invalid memory group. Must be 1-9.");
+    }
+  }
+  else if (command.startsWith("setmem ")) {
+    // Format: setmem N param value
+    // Example: setmem 1 v 12.5
+    command = command.substring(7); // Remove "setmem "
+    int firstSpace = command.indexOf(' ');
+    
+    if (firstSpace > 0) {
+      int groupNum = command.substring(0, firstSpace).toInt();
+      command = command.substring(firstSpace + 1);
+      int secondSpace = command.indexOf(' ');
+      
+      if (secondSpace > 0 && groupNum >= 0 && groupNum <= 9) {
+        String param = command.substring(0, secondSpace);
+        float value = command.substring(secondSpace + 1).toFloat();
+        xy_sk::MemoryGroup group = static_cast<xy_sk::MemoryGroup>(groupNum);
+        xy_sk::GroupRegisterOffset regOffset;
+        uint16_t rawValue = 0;
+        bool validParam = true;
+        
+        // Convert to appropriate register and raw value
+        if (param == "v" || param == "voltage") {
+          regOffset = xy_sk::GroupRegisterOffset::VOLTAGE_SET;
+          rawValue = static_cast<uint16_t>(value * 100);
+        }
+        else if (param == "i" || param == "current") {
+          regOffset = xy_sk::GroupRegisterOffset::CURRENT_SET;
+          rawValue = static_cast<uint16_t>(value * 1000);
+        }
+        else if (param == "p" || param == "power") {
+          regOffset = xy_sk::GroupRegisterOffset::POWER_SET;
+          rawValue = static_cast<uint16_t>(value * 100);
+        }
+        else if (param == "ovp") {
+          regOffset = xy_sk::GroupRegisterOffset::OVP_SET;
+          rawValue = static_cast<uint16_t>(value * 100);
+        }
+        else if (param == "ocp") {
+          regOffset = xy_sk::GroupRegisterOffset::OCP_SET;
+          rawValue = static_cast<uint16_t>(value * 1000);
+        }
+        else if (param == "opp") {
+          regOffset = xy_sk::GroupRegisterOffset::OPP_SET;
+          // Fix the OPP scaling - changed multiplier from 100 to 10 to match device
+          rawValue = static_cast<uint16_t>(value * 10);
+        }
+        else if (param == "oah") {
+          regOffset = xy_sk::GroupRegisterOffset::OAH_SET;
+          rawValue = static_cast<uint16_t>(value * 1000);
+        }
+        else if (param == "owh") {
+          regOffset = xy_sk::GroupRegisterOffset::OWH_SET;
+          rawValue = static_cast<uint16_t>(value * 100);
+        }
+        else if (param == "uvp") {
+          regOffset = xy_sk::GroupRegisterOffset::UVP_SET;
+          rawValue = static_cast<uint16_t>(value * 100);
+        }
+        else if (param == "ucp") {
+          regOffset = xy_sk::GroupRegisterOffset::UCP_SET;
+          rawValue = static_cast<uint16_t>(value * 1000);
+        }
+        else {
+          validParam = false;
+          Serial.println("Invalid parameter. Use v, i, p, ovp, ocp, opp, oah, owh, uvp, ucp");
+        }
+        
+        if (validParam) {
+          Serial.print("Setting ");
+          Serial.print(param);
+          Serial.print(" to ");
+          Serial.print(value);
+          Serial.print(" in memory group M");
+          Serial.println(groupNum);
+          
+          bool success = xy_sk::DataGroupManager::writeGroupRegister(
+            group,
+            regOffset,
+            rawValue,
+            [powerSupply](uint16_t addr, uint16_t value) -> bool {
+              // Use the new writeRegister method
+              return powerSupply->writeRegister(addr, value);
+            });
+            
+          if (success) {
+            Serial.println("Parameter updated successfully");
+            // Show the updated memory group
+            displayMemoryGroup(powerSupply, group);
+          } else {
+            Serial.println("Failed to update parameter");
+          }
+        }
+      } else {
+        Serial.println("Invalid format. Use: setmem [group 0-9] [param] [value]");
+      }
+    } else {
+      Serial.println("Invalid format. Use: setmem [group 0-9] [param] [value]");
+    }
+  }
+  // Debug commands for direct register access
+  else if (command.startsWith("read ")) {
+    command = command.substring(5); // Remove "read "
+    int spaceIndex = command.indexOf(' ');
+    
+    if (spaceIndex > 0) {
+      uint16_t addr = strtoul(command.substring(0, spaceIndex).c_str(), NULL, 0);
+      uint8_t count = command.substring(spaceIndex + 1).toInt();
+      
+      if (count > 0 && count <= 125) {
+        Serial.print("Reading ");
+        Serial.print(count);
+        Serial.print(" registers starting at address 0x");
+        Serial.println(addr, HEX);
+        
+        uint16_t values[125]; // Maximum read size for Modbus
+        if (powerSupply->debugReadRegisters(addr, count, values)) {
+          displayRegisterValues(addr, values, count);
+        } else {
+          Serial.println("Failed to read registers");
+        }
+      } else {
+        Serial.println("Invalid count. Must be between 1 and 125.");
+      }
+    } else {
+      Serial.println("Invalid format. Use: read [address] [count]");
+    }
+  }
+  else if (command.startsWith("write ")) {
+    command = command.substring(6); // Remove "write "
+    int spaceIndex = command.indexOf(' ');
+    
+    if (spaceIndex > 0) {
+      uint16_t addr = strtoul(command.substring(0, spaceIndex).c_str(), NULL, 0);
+      uint16_t value = strtoul(command.substring(spaceIndex + 1).c_str(), NULL, 0);
+      
+      Serial.print("Writing value 0x");
+      Serial.print(value, HEX);
+      Serial.print(" (");
+      Serial.print(value);
+      Serial.print(") to register at address 0x");
+      Serial.println(addr, HEX);
+      
+      if (powerSupply->debugWriteRegister(addr, value)) {
+        Serial.println("Success");
+        
+        // Read back the value to confirm
+        uint16_t readback;
+        if (powerSupply->debugReadRegisters(addr, 1, &readback)) {
+          Serial.print("Readback value: 0x");
+          Serial.print(readback, HEX);
+          Serial.print(" (");
+          Serial.print(readback);
+          Serial.println(")");
+        }
+      } else {
+        Serial.println("Failed to write to register");
+      }
+    } else {
+      Serial.println("Invalid format. Use: write [address] [value]");
+    }
+  }
+  else if (command.startsWith("writes ")) {
+    command = command.substring(7); // Remove "writes "
+    int spaceIndex = command.indexOf(' ');
+    
+    if (spaceIndex > 0) {
+      uint16_t addr = strtoul(command.substring(0, spaceIndex).c_str(), NULL, 0);
+      command = command.substring(spaceIndex + 1);
+      
+      // Parse all remaining values
+      uint16_t values[123]; // Maximum write size for Modbus
+      uint8_t count = 0;
+      
+      while (command.length() > 0 && count < 123) {
+        spaceIndex = command.indexOf(' ');
+        String valueStr;
+        
+        if (spaceIndex > 0) {
+          valueStr = command.substring(0, spaceIndex);
+          command = command.substring(spaceIndex + 1);
+        } else {
+          valueStr = command;
+          command = "";
+        }
+        
+        if (valueStr.length() > 0) {
+          values[count++] = strtoul(valueStr.c_str(), NULL, 0);
+        }
+      }
+      
+      if (count > 0) {
+        Serial.print("Writing ");
+        Serial.print(count);
+        Serial.print(" values to registers starting at address 0x");
+        Serial.println(addr, HEX);
+        
+        if (powerSupply->debugWriteRegisters(addr, count, values)) {
+          Serial.println("Success");
+          
+          // Read back the values to confirm
+          uint16_t readback[123];
+          if (powerSupply->debugReadRegisters(addr, count, readback)) {
+            displayRegisterValues(addr, readback, count);
+          }
+        } else {
+          Serial.println("Failed to write to registers");
+        }
+      } else {
+        Serial.println("No values provided");
+      }
+    } else {
+      Serial.println("Invalid format. Use: writes [address] [value1] [value2] ...");
+    }
+  }
   else {
     Serial.println("Unknown command. Type 'help' for available commands.");
   }
 }
 
 void setupSerialMonitorControl() {
-  Serial.println("\nAvailable Commands - type 'help' for full list");
-  printHelp();
+  Serial.println("\nXY-SK120 Serial Monitor Control");
+  Serial.println("Type 'help' for available commands");
 }
 
 void checkSerialMonitorInput(XY_SKxxx* powerSupply, XYModbusConfig &config) {


### PR DESCRIPTION
# Memory Groups and Debug Functions Support

This PR adds two important capabilities to the XY-SK120 Modbus RTU control project:

## 1. Enhanced Memory Group Functionality

* Improved memory group display with human-readable information for all parameters
* Fixed display of OPP (Over Power Protection) values using the correct scaling factor
* Added detailed parameter explanations in the memory group display
* Updated the `call` command to display the source memory group instead of M0

## 2. New Debug Functions for Direct Register Access

Added three powerful debug commands to the serial monitor interface:

* `read addr count` - Read multiple registers starting at a specific address
* `write addr value` - Write a value to a specific register
* `writes addr v1 v2 ...` - Write multiple values to consecutive registers

These commands support both decimal and hexadecimal input formats (with 0x prefix) and display register values in multiple formats for easy analysis.

## Implementation Details

* All debugging functions are implemented in a new file: `XY-SKxxx-read-write-registers.cpp`
* The functions operate directly on Modbus registers without affecting the device's cache
* Register values are displayed with various scaling factors (1/10, 1/100, 1/1000) to help identify the correct interpretation
* Comprehensive documentation added to both the library and project README files

## Documentation

Updated documentation for the new functions including:

* Usage examples for the debug functions
* Register map information
* Common voltage and current register addresses

These enhancements provide a much more powerful interface for advanced users who need to work directly with the device's registers, while maintaining the user-friendly high-level API for common operations.